### PR TITLE
Fix for Fluid Dupe with Barrels and Lg Vessel

### DIFF
--- a/src/Common/com/bioxx/tfc/Items/ItemBlocks/ItemBarrels.java
+++ b/src/Common/com/bioxx/tfc/Items/ItemBlocks/ItemBarrels.java
@@ -2,6 +2,7 @@ package com.bioxx.tfc.Items.ItemBlocks;
 
 import java.util.List;
 
+import com.bioxx.tfc.api.TFCFluids;
 import net.minecraft.block.Block;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
@@ -134,28 +135,38 @@ public class ItemBarrels extends ItemTerraBlock implements IEquipable
 				int j = mop.blockY;
 				int k = mop.blockZ;
 
-				if (!player.canPlayerEdit(i, j, k, mop.sideHit, is) || !(world.getBlock(i, j, k) instanceof IFluidBlock) || is.hasTagCompound())
-				{
+				if (!player.canPlayerEdit(i, j, k, mop.sideHit, is) || !(world.getBlock(i, j, k) instanceof IFluidBlock) || is.hasTagCompound()) {
 					return super.onItemUse(is, player, world, x, y, z, side, hitX, hitY, hitZ);
 				}
 
-				Fluid fluid = ((IFluidBlock)world.getBlock(i, j, k)).getFluid();
-
-				world.setBlockToAir(i, j, k);
-
-				if (is.stackSize == 1)
+				Fluid fluid = ((IFluidBlock) world.getBlock(i, j, k)).getFluid();
+				int temp = fluid.getTemperature();
+				int v = 0;
+				if (temp < 575)
 				{
-					ItemBarrels.fillItemBarrel(is, new FluidStack(fluid, 10000), 10000);	
-				}	
-				else
-				{
+					world.setBlockToAir(i, j, k);
+
+					if (fluid == TFCFluids.FRESHWATER || fluid == TFCFluids.SALTWATER)
+					{
+						v = 10000;
+					}
+					else
+						v = 1000;
+
+					if (is.stackSize == 1)
+					{
+						ItemBarrels.fillItemBarrel(is, new FluidStack(fluid, v), 10000);
+					}
+					else
+					{
 					is.stackSize--;
 					ItemStack outIS = is.copy();
 					outIS.stackSize = 1;
-					ItemBarrels.fillItemBarrel(outIS, new FluidStack(fluid, 10000), 10000);
+					ItemBarrels.fillItemBarrel(outIS, new FluidStack(fluid, v), 10000);
 					if (!player.inventory.addItemStackToInventory(outIS))
 					{
 						player.entityDropItem(outIS, 0);
+					}
 					}
 				}
 				return true;

--- a/src/Common/com/bioxx/tfc/Items/ItemBlocks/ItemLargeVessel.java
+++ b/src/Common/com/bioxx/tfc/Items/ItemBlocks/ItemLargeVessel.java
@@ -2,6 +2,7 @@ package com.bioxx.tfc.Items.ItemBlocks;
 
 import java.util.List;
 
+import com.bioxx.tfc.api.TFCFluids;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -140,28 +141,38 @@ public class ItemLargeVessel extends ItemTerraBlock implements IEquipable
 				int j = mop.blockY;
 				int k = mop.blockZ;
 
-				if (!player.canPlayerEdit(i, j, k, mop.sideHit, is) || !(world.getBlock(i, j, k) instanceof IFluidBlock) || is.hasTagCompound() || is.getItemDamage() == 0)
-				{
+				if (!player.canPlayerEdit(i, j, k, mop.sideHit, is) || !(world.getBlock(i, j, k) instanceof IFluidBlock) || is.hasTagCompound()) {
 					return super.onItemUse(is, player, world, x, y, z, side, hitX, hitY, hitZ);
 				}
 
-				Fluid fluid = ((IFluidBlock)world.getBlock(i, j, k)).getFluid();
-
-				world.setBlockToAir(i, j, k);
-
-				if (is.stackSize == 1)
+				Fluid fluid = ((IFluidBlock) world.getBlock(i, j, k)).getFluid();
+				int temp = fluid.getTemperature();
+				int v = 0;
+				if (temp < 575)
 				{
-					ItemBarrels.fillItemBarrel(is, new FluidStack(fluid, 5000), 5000);
-				}
-				else
-				{
-					is.stackSize--;
-					ItemStack outIS = is.copy();
-					outIS.stackSize = 1;
-					ItemBarrels.fillItemBarrel(outIS, new FluidStack(fluid, 5000), 5000);
-					if (!player.inventory.addItemStackToInventory(outIS))
+					world.setBlockToAir(i, j, k);
+
+					if (fluid == TFCFluids.FRESHWATER || fluid == TFCFluids.SALTWATER)
 					{
-						player.entityDropItem(outIS, 0);
+						v = 5000;
+					}
+					else
+						v = 1000;
+
+					if (is.stackSize == 1)
+					{
+						ItemBarrels.fillItemBarrel(is, new FluidStack(fluid, v), 5000);
+					}
+					else
+					{
+						is.stackSize--;
+						ItemStack outIS = is.copy();
+						outIS.stackSize = 1;
+						ItemBarrels.fillItemBarrel(outIS, new FluidStack(fluid, v), 5000);
+						if (!player.inventory.addItemStackToInventory(outIS))
+						{
+							player.entityDropItem(outIS, 0);
+						}
 					}
 				}
 				return true;

--- a/src/Common/com/bioxx/tfc/TileEntities/TEBarrel.java
+++ b/src/Common/com/bioxx/tfc/TileEntities/TEBarrel.java
@@ -246,7 +246,7 @@ public class TEBarrel extends NetworkTileEntity implements IInventory
 		if (inFS != null)
 		{
 			//We dont want very hot liquids stored here so if they are much hotter than boiling water, we prevent it. 
-			if (inFS.getFluid() != null && inFS.getFluid().getTemperature(inFS) > 385)
+			if (inFS.getFluid() != null && inFS.getFluid().getTemperature(inFS) > 575)
 				return false;
 
 			if (fluid == null)


### PR DESCRIPTION
Fixes the volume picked up by scooping up 1 block of fluid to be 1000mb
for all fluids except TFC fresh and salt water. Prevents picking up hot
fluids. Adjusts fluid heat to 575K as this is roughly the ignition
temperature of wood.
